### PR TITLE
Fix typos and add `codespell` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,3 +69,9 @@ repos:
         exclude: 'sevenn/pair_e3gnn/pair_e3gnn_parallel.h'
         exclude: 'sevenn/pair_e3gnn/comm_brick.h'
         exclude: 'sevenn/pair_e3gnn/comm_brick.cpp'
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+        stages: [commit, commit-msg]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,3 +75,4 @@ repos:
     hooks:
       - id: codespell
         stages: [commit, commit-msg]
+        args: ["--ignore-words-list", "Commun"]

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ You can refer to `sevenn/pair_e3gnn/patch_lammps.sh` for the detailed patch proc
 
 Build LAMMPS with cmake (example):
 
-```
+```bash
 cd ./lammps_sevenn
 mkdir build
 cd build

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 
-
 <img src="SevenNet_logo.png" alt="Alt text" height="180">
-
 
 # SevenNet
 
@@ -12,32 +10,33 @@ The project provides parallel molecular dynamics simulations using graph neural 
 The installation and usage of SevenNet are split into two parts: training + command-line interface + ASE calculator (handled by Python) and molecular dynamics (handled by [`LAMMPS`](https://docs.lammps.org/Manual.html)).
 
 - [SevenNet](#sevennet)
-  * [Installation](#installation)
-  * [Usage](#usage)
-    + [SevenNet-0](#sevennet-0)
-    + [SevenNet Calculator for ASE](#sevennet-calculator-for-ase)
-    + [Training sevenn](#training)
+  - [Installation](#installation)
+  - [Usage](#usage)
+    - [SevenNet-0](#sevennet-0)
+    - [SevenNet Calculator for ASE](#sevennet-calculator-for-ase)
+    - [Training sevenn](#training)
       - [Multi-GPU training](#multi-gpu-training)
-    + [sevenn_graph build](#sevenn_graph_build)
-    + [sevenn_inference](#sevenn_inference)
-    + [sevenn_get_model](#sevenn_get_model)
-  * [Installation for LAMMPS](#installation-for-lammps)
-  * [Usage for LAMMPS](#usage-for-lammps)
-    + [To check installation](#to-check-installation)
-    + [For serial model](#for-serial-model)
-    + [For parallel model](#for-parallel-model)
-  * [Future Works](#future-works)
-  * [Citation](#citation)
+    - [sevenn_graph build](#sevenn_graph_build)
+    - [sevenn_inference](#sevenn_inference)
+    - [sevenn_get_model](#sevenn_get_model)
+  - [Installation for LAMMPS](#installation-for-lammps)
+  - [Usage for LAMMPS](#usage-for-lammps)
+    - [To check installation](#to-check-installation)
+    - [For serial model](#for-serial-model)
+    - [For parallel model](#for-parallel-model)
+  - [Future Works](#future-works)
+  - [Citation](#citation)
 
 ## Installation
 
-* Python >= 3.8
-* PyTorch >= 1.12.0
+- Python >= 3.8
+- PyTorch >= 1.12.0
 
 Please install PyTorch from [`PyTorch official`](https://pytorch.org/get-started/locally/) before installing the SevenNet.
 Note that for SevenNet, `torchvision` and `torchaudio` are redundant. You can safely exclude these packages from the installation commands.
 
 Here are the recommended versions we've been using internally without any issues.
+
 - PyTorch/2.2.2 + CUDA/12.1.0
 - PyTorch/1.13.1 + CUDA/12.1.0
 - PyTorch/1.12.0 + CUDA/11.6.2
@@ -47,6 +46,7 @@ Using the newer versions of CUDA with PyTorch is usually not a problem. For exam
 **PLEASE NOTE:** You must install PyTorch before installing SevenNet. They are not marked as dependencies since it is coupled with the CUDA version.
 
 After the PyTorch installation, run
+
 ```bash
 pip install sevenn
 ```
@@ -54,9 +54,11 @@ pip install sevenn
 ## Usage
 
 ### SevenNet-0
+
 SevenNet-0 is a general-purpose interatomic potential trained on the [`MPF dataset of M3GNet`](https://figshare.com/articles/dataset/MPF_2021_2_8/19470599) or [`MPtrj dataset of CHGNet`](https://figshare.com/articles/dataset/Materials_Project_Trjectory_MPtrj_Dataset/23713842). You can try SevenNet-0 to your application without any training. If the accuracy is unsatisfactory, SevenNet-0 can be [fine-tuned](#training).
 
 #### SevenNet-0 (11July2024)
+
 This model was trained on [`MPtrj`](https://figshare.com/articles/dataset/Materials_Project_Trjectory_MPtrj_Dataset/23713842). We suggest starting with this model as we found that it performs better than the previous SevenNet-0 (22May2024). Check [`Matbench Discovery leaderborad`](https://matbench-discovery.materialsproject.org/) for this model's performance on materials discovery. For more information, click [here](sevenn/pretrained_potentials/SevenNet_0__11July2024).
 
 Whenever the checkpoint path is the input, this model can be loaded via `7net-0 | SevenNet-0 | 7net-0_11July2024 | SevenNet-0_11July2024` keywords.
@@ -64,6 +66,7 @@ Whenever the checkpoint path is the input, this model can be loaded via `7net-0 
 **Acknowledgments**: This work was supported by the Neural Processing Research Center program of Samsung Advanced Institute of Technology, Samsung Electronics Co., Ltd. The computations for training models were carried out using the Samsung SSC-21 cluster.
 
 #### SevenNet-0 (22May2024)
+
 This model was trained on [`MPF.2021.2.8`](https://figshare.com/articles/dataset/MPF_2021_2_8/19470599). This is the model used in [our paper](https://pubs.acs.org/doi/10.1021/acs.jctc.4c00190). For more information, click [here](sevenn/pretrained_potentials/SevenNet_0__22May2024).
 
 Whenever the checkpoint path is the input, this model can be loaded via `7net-0_22May2024 | SevenNet-0_22May2024` keywords.
@@ -73,12 +76,14 @@ Whenever the checkpoint path is the input, this model can be loaded via `7net-0_
 [ASE (Atomic Simulation Environment)](https://wiki.fysik.dtu.dk/ase/) is a set of tools and Python modules for atomistic simulations. SevenNet-0 and SevenNet-trained potentials can be used with ASE for its use in python.
 
 For pre-trained models,
+
 ```python
 from sevenn.sevennet_calculator import SevenNetCalculator
 sevenet_0_cal = SevenNetCalculator("7net-0", device='cpu')  # 7net-0, SevenNet-0, 7net-0_22May2024, 7net-0_11July2024 ...
 ```
 
 For user trained models,
+
 ```python
 from sevenn.sevennet_calculator import SevenNetCalculator
 checkpoint_path = ### PATH TO CHECKPOINT ###
@@ -98,13 +103,17 @@ Check comments of `base` yaml for explanations.
 To reuse a preprocessed training set, you can specify `${dataset_name}.sevenn_data` to the `load_dataset_path:` in the `input.yaml`.
 
 #### Multi-GPU training
+
 We support multi-GPU training features using PyTorch DDP (distributed data parallel). We use one process (or a CPU core) per GPU.
+
 ```bash
 torchrun --standalone --nnodes {number of nodes} --nproc_per_node {number of GPUs} --no_python sevenn input.yaml -d
 ```
+
 Please note that `batch_size` in input.yaml indicates `batch_size` per GPU.
 
 ### sevenn_graph_build
+
 ```bash
 sevenn_graph_build -f ase my_train_data.extxyz 5.0
 ```
@@ -113,32 +122,39 @@ You can preprocess the dataset with `sevenn_graph_build` to obtain `*.sevenn_dat
 See `sevenn_graph_build --help` for more information.
 
 ### sevenn_inference
+
 ```bash
 sevenn_inference checkpoint_best.pt path_to_my_structures/*
 ```
+
 This will create dir `sevenn_infer_result`. It includes .csv files that enumerate prediction/reference results of energy and force.
 See `sevenn_inference --help` for more information.
 
 ### sevenn_get_model
+
 This command is for deploying lammps potentials from checkpoints. The argument is either the path to checkpoint or the name of pre-trained potential.
+
 ```bash
 sevenn_get_model 7net-0
 ```
-This will create `deployed_serial.pt`, which can be used as lammps potential under `e3gnn` pair_style. 
+
+This will create `deployed_serial.pt`, which can be used as lammps potential under `e3gnn` pair_style.
 
 The parallel model can be obtained in a similar way
+
 ```bash
 sevenn_get_model 7net-0 -p
 ```
+
 This will create multiple `deployed_parallel_*.pt` files. The number of deployed models equals the number of message-passing layers.
 These models can be used as lammps potential to run parallel MD simulations with GNN potential using multiple GPU cards.
 
 ## Installation for LAMMPS
 
-* PyTorch (same version as used for training)
-* LAMMPS version of 'stable_2Aug2023_update3' [`LAMMPS`](https://github.com/lammps/lammps)
-* (Optional) [`CUDA-aware OpenMPI`](https://www.open-mpi.org/faq/?category=buildcuda) for parallel MD
-* MKL-include
+- PyTorch (same version as used for training)
+- LAMMPS version of 'stable_2Aug2023_update3' [`LAMMPS`](https://github.com/lammps/lammps)
+- (Optional) [`CUDA-aware OpenMPI`](https://www.open-mpi.org/faq/?category=buildcuda) for parallel MD
+- MKL-include
 
 **PLEASE NOTE:** CUDA-aware OpenMPI does not support NVIDIA Gaming GPUs. Given that the software is closely tied to hardware specifications, please consult with your server administrator if unavailable.
 
@@ -147,37 +163,46 @@ If your cluster supports the Intel MKL module (often included with Intel OneAPI,
 CUDA-aware OpenMPI is optional but recommended for parallel MD. If it is not available, in parallel mode, GPUs will communicate via CPU. It is still faster than using only one GPU, but its efficiency is low.
 
 Ensure the LAMMPS version (stable_2Aug2023_update3). You can easily switch the version using git. After switching the version, run `sevenn_patch_lammps` with the lammps directory path as an argument.
+
 ```bash
 git clone https://github.com/lammps/lammps.git lammps_sevenn --branch stable_2Aug2023_update3 --depth=1
 sevenn_patch_lammps ./lammps_sevenn
 ```
+
 You can refer to `sevenn/pair_e3gnn/patch_lammps.sh` for the detailed patch process.
 
 Build LAMMPS with cmake (example):
+
 ```
-$ cd ./lammps_sevenn
-$ mkdir build
-$ cd build
-$ cmake ../cmake -DCMAKE_PREFIX_PATH=`python -c 'import torch;print(torch.utils.cmake_prefix_path)'`
-$ make -j4
+cd ./lammps_sevenn
+mkdir build
+cd build
+cmake ../cmake -DCMAKE_PREFIX_PATH=`python -c 'import torch;print(torch.utils.cmake_prefix_path)'`
+make -j4
 ```
 
 If the compilation is successful, you will find the executable at `{path_to_lammps_dir}/build/lmp`. To use this binary easily, for example, create a soft link in your bin directory (which should be included in your $PATH).
+
 ```bash
 ln -s {absolute_path_to_lammps_dir}/build/lmp $HOME/.local/bin/lmp
 ```
+
 This will allow you to run the binary using `lmp -in my_lammps_script.lmp`.
 
 ### Note for MKL
+
 You may encounter `MKL_INCLUDE_DIR NOT-FOUND` during cmake. This usually means the environment variable is not set correctly, or mkl-include is not present on your system.
 
 Install mkl-include with:
+
 ```bash
 conda install -c intel mkl-include
 ```
+
 If you encounter an error, remove `-c intel`. This is a known bug in the recent Conda version.
 
 Append the following to your cmake command:
+
 ```bash
 -DMKL_INCLUDE_DIR=$CONDA_PREFIX/include
 ```
@@ -193,11 +218,12 @@ For other error cases, you might want to check [`pair-nequip`](https://github.co
 ```bash
 {lammps_binary} -help | grep e3gnn
 ```
+
 You will see `e3gnn` and `e3gnn/parallel` as pair_style.
 
 ### For serial model
 
-```
+```txt
 units         metal
 atom_style    atomic
 pair_style e3gnn
@@ -206,7 +232,7 @@ pair_coeff * * {path to serial model} {space separated chemical species}
 
 ### For parallel model
 
-```
+```txt
 units         metal
 atom_style    atomic
 pair_style e3gnn/parallel
@@ -214,10 +240,12 @@ pair_coeff * * {number of segmented parallel models} {space separated paths of s
 ```
 
 For example,
-```
+
+```txt
 pair_style e3gnn/parallel
 pair_coeff * * 4 ./deployed_parallel_0.pt ./deployed_parallel_1.pt ./deployed_parallel_2.pt ./deployed_parallel_3.pt Hf O
 ```
+
 The number of segmented `*.pt` files is same as the number of message-passing layers of the model.
 
 Check [sevenn_get_model](#sevenn_get_model) for deploying lammps models from checkpoint for both serial and parallel.
@@ -228,12 +256,13 @@ One GPU per MPI process is expected. The simulation may run inefficiently if the
 
 ## Future Works
 
-* Notebook examples and improved interface for non-command line usage
-* Implementation of pressure output in parallel MD simulations.
-* Development of support for a tiled communication style (also known as recursive coordinate bisection, RCB) in LAMMPS.
-* Easy use of parallel models
+- Notebook examples and improved interface for non-command line usage
+- Implementation of pressure output in parallel MD simulations.
+- Development of support for a tiled communication style (also known as recursive coordinate bisection, RCB) in LAMMPS.
+- Easy use of parallel models
 
 ## Citation
+
 If you use SevenNet, please cite (1) parallel GNN-IP MD simulation by SevenNet or its pre-trained model SevenNet-0, (2) underlying GNN-IP architecture NequIP
 
 (1) Y. Park, J. Kim, S. Hwang, and S. Han, "Scalable Parallel Algorithm for Graph Neural Network Interatomic Potentials in Molecular Dynamics Simulations". J. Chem. Theory Comput., 20(11), 4857 (2024) (https://pubs.acs.org/doi/10.1021/acs.jctc.4c00190)

--- a/sevenn/_const.py
+++ b/sevenn/_const.py
@@ -10,7 +10,7 @@ from sevenn.nn.activation import ShiftedSoftPlus
 SEVENN_VERSION = '0.9.3'
 IMPLEMENTED_RADIAL_BASIS = ['bessel']
 IMPLEMENTED_CUTOFF_FUNCTION = ['poly_cut', 'XPLOR']
-# TODO: support None. This became difficult because of paralell model
+# TODO: support None. This became difficult because of parallel model
 IMPLEMENTED_SELF_CONNECTION_TYPE = ['nequip', 'linear']
 
 IMPLEMENTED_SHIFT = ['per_atom_energy_mean', 'elemwise_reference_energies']

--- a/sevenn/_keys.py
+++ b/sevenn/_keys.py
@@ -41,7 +41,7 @@ NODE_ATTR: Final[str] = 'node_attr'  # (N, N_species) from one_hot
 EDGE_ATTR: Final[str] = 'edge_attr'  # (from spherical harmonics)
 EDGE_EMBEDDING: Final[str] = 'edge_embedding'  # (from edge embedding)
 
-# inputs of loss fuction
+# inputs of loss function
 ENERGY: Final[str] = 'total_energy'  # (1)
 FORCE: Final[str] = 'force_of_atoms'  # (N, 3)
 STRESS: Final[str] = 'stress'  # (6)

--- a/sevenn/atom_graph_data.py
+++ b/sevenn/atom_graph_data.py
@@ -34,7 +34,7 @@ class AtomGraphData(torch_geometric.data.Data):
             self[k] = v
 
     def to_numpy_dict(self):
-        # This is not debuged yet!
+        # This is not debugged yet!
         dct = {
             k: v.detach().cpu().numpy() if type(v) is torch.Tensor else v
             for k, v in self.items()

--- a/sevenn/main/sevenn.py
+++ b/sevenn/main/sevenn.py
@@ -19,7 +19,7 @@ working_dir_help = 'path to write output. Default is cwd.'
 screen_help = 'print log to stdout'
 distributed_help = 'set this flag if it is distributed training'
 
-# TODO: do somthing for model type (it is not printed on log)
+# TODO: do something for model type (it is not printed on log)
 global_config = {
     'version': SEVENN_VERSION,
     KEY.MODEL_TYPE: 'E3_equivariant_model',

--- a/sevenn/main/sevenn_graph_build.py
+++ b/sevenn/main/sevenn_graph_build.py
@@ -18,7 +18,7 @@ cutoff_help = 'cutoff radius of edges in Angstrom'
 suffix_help = 'when source is dir, suffix of the files.'
 copy_info_help = 'copy ase.Atoms.info to output dataset'
 format_help = (
-    'type of the source, defualt is structure_list. '
+    'type of the source, default is structure_list. '
     + 'If it is pkl/pickle, assume they are list of ase.Atoms. '
     + 'Otherwise, it is directly passed to ase.io.read'
 )

--- a/sevenn/model_build.py
+++ b/sevenn/model_build.py
@@ -279,7 +279,7 @@ def build_E3_equivariant_model(config: dict, parallel=False):
             layers = layers_list[layers_idx]
             # communication from lammps here
 
-        # convolution part, l>lmax is droped as defined in irreps_out
+        # convolution part, l>lmax is dropped as defined in irreps_out
         interaction_block[f'{i}_convolution'] = IrrepsConvolution(
             irreps_x=irreps_x,
             irreps_filter=irreps_spherical_harm,

--- a/sevenn/nn/scale.py
+++ b/sevenn/nn/scale.py
@@ -50,7 +50,7 @@ class SpeciesWiseRescale(nn.Module):
         scale: List[float],
         data_key_in=KEY.SCALED_ATOMIC_ENERGY,
         data_key_out=KEY.ATOMIC_ENERGY,
-        data_key_indicies=KEY.ATOM_TYPE,
+        data_key_indices=KEY.ATOM_TYPE,
         train_shift_scale: bool = False,
     ):
         super().__init__()
@@ -62,12 +62,12 @@ class SpeciesWiseRescale(nn.Module):
         )
         self.key_input = data_key_in
         self.key_output = data_key_out
-        self.key_indicies = data_key_indicies
+        self.key_indices = data_key_indices
 
     def forward(self, data: AtomGraphDataType) -> AtomGraphDataType:
-        indicies = data[self.key_indicies]
+        indices = data[self.key_indices]
         data[self.key_output] = data[self.key_input] * self.scale[
-            indicies
-        ].view(-1, 1) + self.shift[indicies].view(-1, 1)
+            indices
+        ].view(-1, 1) + self.shift[indices].view(-1, 1)
 
         return data

--- a/sevenn/scripts/inference.py
+++ b/sevenn/scripts/inference.py
@@ -221,7 +221,7 @@ def inference_main(
             output_list.extend(to_atom_graph_list(output))  # unroll batch data
     except Exception as e:
         print(e)
-        print("Keeping 'info' failed. Try with separted info")
+        print("Keeping 'info' failed. Try with separated info")
         infer_list, info_list = inference_set.seperate_info()
         loader = DataLoader(infer_list, batch_size=batch_size, shuffle=False)
         output_list = []

--- a/sevenn/scripts/processing_dataset.py
+++ b/sevenn/scripts/processing_dataset.py
@@ -90,7 +90,7 @@ def handle_shift_scale(config, train_set, checkpoint_given):
         # Values extracted from checkpoint in processing_continue.py
         shift = config[KEY.SHIFT + '_cp']
         scale = config[KEY.SCALE + '_cp']
-        # shift & scale would be both array (with same lenght) or scalar
+        # shift & scale would be both array (with same length) or scalar
         assert len(list(shift)) == len(list(scale))
         if len(list(shift)) > 1:
             use_species_wise_shift_scale = True

--- a/sevenn/scripts/train.py
+++ b/sevenn/scripts/train.py
@@ -59,7 +59,7 @@ def train(config, working_dir: str):
         state_dicts, start_epoch, init_csv = None, 1, True
 
     # config updated
-    # Note that continue and dataset cannot be seperated completely
+    # Note that continue and dataset cannot be separated completely
     data_lists = processing_dataset(config, working_dir)
     loaders = init_loaders(*data_lists, config)
 

--- a/sevenn/sevenn_logger.py
+++ b/sevenn/sevenn_logger.py
@@ -207,27 +207,27 @@ class Logger(metaclass=Singleton):
     @staticmethod
     def format_k_v(key, val, write=False):
         MAX_KEY_SIZE = 20
-        SPERATOR = ', '
+        SEPARATOR = ', '
         EMPTY_PADDING = ' ' * (MAX_KEY_SIZE + 3)
         NEW_LINE_LEN = Logger.SCREEN_WIDTH - 5
         val = str(val)
         content = f'{key:<{MAX_KEY_SIZE}}: {val}'
         if len(content) > NEW_LINE_LEN:
             content = f'{key:<{MAX_KEY_SIZE}}: '
-            # sperate val by sperator
-            val_list = val.split(SPERATOR)
+            # septate val by separator
+            val_list = val.split(SEPARATOR)
             current_len = len(content)
             for val_compo in val_list:
                 current_len += len(val_compo)
                 if current_len > NEW_LINE_LEN:
-                    newline_content = f'{EMPTY_PADDING}{val_compo}{SPERATOR}'
+                    newline_content = f'{EMPTY_PADDING}{val_compo}{SEPARATOR}'
                     content += f'\\\n{newline_content}'
                     current_len = len(newline_content)
                 else:
-                    content += f'{val_compo}{SPERATOR}'
+                    content += f'{val_compo}{SEPARATOR}'
 
-        if content.endswith(f'{SPERATOR}'):
-            content = content[: -len(SPERATOR)]
+        if content.endswith(f'{SEPARATOR}'):
+            content = content[: -len(SEPARATOR)]
         content += '\n'
 
         if write is False:
@@ -255,7 +255,7 @@ class Logger(metaclass=Singleton):
         print some important information from config
         """
         content = (
-            'succesfully read yaml config!\n\n' + 'from model configuration\n'
+            'successfully read yaml config!\n\n' + 'from model configuration\n'
         )
         for k, v in model_config.items():
             content += Logger.format_k_v(k, v)
@@ -271,10 +271,10 @@ class Logger(metaclass=Singleton):
     def error(self, e: Exception):
         content = ''
         if type(e) is ValueError:
-            content += 'Error occured!\n'
+            content += 'Error occurred!\n'
             content += str(e) + '\n'
         else:
-            content += 'Unknown error occured!\n'
+            content += 'Unknown error occurred!\n'
             content += traceback.format_exc()
         self.write(content)
 

--- a/sevenn/train/dataset.py
+++ b/sevenn/train/dataset.py
@@ -50,7 +50,7 @@ class AtomGraphDataset:
             dataset (Union[Dict[str, List], List]: dataset as dict or pure list
             metadata (Dict, Optional): metadata of data
             cutoff (float): cutoff radius of graphs inside the dataset
-            x_is_one_hot_idx (bool): if True, x is one_hot_idx, eles 'Z'
+            x_is_one_hot_idx (bool): if True, x is one_hot_idx, else 'Z'
 
         'x' (node feature) of dataset can have 3 states, atomic_numbers,
         one_hot_idx, or one_hot_vector.
@@ -102,7 +102,7 @@ class AtomGraphDataset:
 
     def seperate_info(self, data_key=KEY.INFO):
         """
-        seperate info from data and save it as list of dict
+        Separate info from data and save it as list of dict
         to make it compatible with torch_geometric and later training
         """
         data_list = self.to_list()
@@ -119,7 +119,7 @@ class AtomGraphDataset:
 
     def get_species(self):
         """
-        You can also use get_natoms and extract keys from there istead of this
+        You can also use get_natoms and extract keys from there instead of this
         (And it is more efficient)
         get chemical species of dataset
         return list of SORTED chemical species (as str)
@@ -294,13 +294,13 @@ class AtomGraphDataset:
         y = y.numpy()
 
         # tweak to fine tune training from many-element to small element
-        zero_indicies = np.all(c == 0, axis=0)
-        c_reduced = c[:, ~zero_indicies]
+        zero_indices = np.all(c == 0, axis=0)
+        c_reduced = c[:, ~zero_indices]
         full_coeff = np.zeros(num_chem_species)
         coef_reduced = (
             Ridge(alpha=0.1, fit_intercept=False).fit(c_reduced, y).coef_
         )
-        full_coeff[~zero_indicies] = coef_reduced
+        full_coeff[~zero_indices] = coef_reduced
 
         return full_coeff
 
@@ -385,7 +385,7 @@ class AtomGraphDataset:
         return res
 
     def augment(self, dataset, validator: Optional[Callable] = None):
-        """check meta compatiblity here
+        """check meta compatibility here
         dataset(AtomGraphDataset): data to augment
         validator(Callable, Optional): function(self, dataset) -> bool
 

--- a/sevenn/util.py
+++ b/sevenn/util.py
@@ -33,7 +33,7 @@ class AverageNumber:
 
 def to_atom_graph_list(atom_graph_batch):
     """
-    torch_geometric batched data to seperate list
+    torch_geometric batched data to separate list
     original to_data_list() by PyG is not enough since
     it doesn't handle inferred tensors
     """
@@ -150,11 +150,11 @@ def squared_error(pred, ref, vdim):
     return torch.reshape(MSE(pred, ref), (-1, vdim)).sum(dim=1)
 
 
-def onehot_to_chem(one_hot_indicies, type_map):
+def onehot_to_chem(one_hot_indices, type_map):
     from ase.data import chemical_symbols
 
     type_map_rev = {v: k for k, v in type_map.items()}
-    return [chemical_symbols[type_map_rev[x]] for x in one_hot_indicies]
+    return [chemical_symbols[type_map_rev[x]] for x in one_hot_indices]
 
 
 def _patch_old_config(config):


### PR DESCRIPTION
best to fix typos early before you gain a large user base if fixing those typos involves breaking changes as is the case here for [`data_key_indic(ie->e)s`](https://github.com/MDIL-SNU/SevenNet/compare/main...janosh:SevenNet:fix-typos?expand=1#diff-f29d11557d77ed3cda288d5c280515c6a08c3766e175ac10c9f3803ffb2e54f8R53)