### PR TITLE
Add a `__version__` attribute

### DIFF
--- a/sevenn/__init__.py
+++ b/sevenn/__init__.py
@@ -1,0 +1,3 @@
+from importlib.metadata import version
+
+__version__ = version("sevenn")

--- a/sevenn/_const.py
+++ b/sevenn/_const.py
@@ -7,7 +7,6 @@ import torch
 import sevenn._keys as KEY
 from sevenn.nn.activation import ShiftedSoftPlus
 
-SEVENN_VERSION = '0.9.4'
 IMPLEMENTED_RADIAL_BASIS = ['bessel']
 IMPLEMENTED_CUTOFF_FUNCTION = ['poly_cut', 'XPLOR']
 # TODO: support None. This became difficult because of parallel model

--- a/sevenn/main/sevenn.py
+++ b/sevenn/main/sevenn.py
@@ -5,13 +5,13 @@ import sys
 import torch.distributed as dist
 
 import sevenn._keys as KEY
-from sevenn._const import SEVENN_VERSION
+from sevenn import __version__
 from sevenn.parse_input import read_config_yaml
 from sevenn.scripts.train import train
 from sevenn.sevenn_logger import Logger
 
 description = (
-    f'sevenn version={SEVENN_VERSION}, train model based on the input.yaml'
+    f'sevenn version={__version__}, train model based on the input.yaml'
 )
 
 input_yaml_help = 'input.yaml for training'
@@ -21,7 +21,7 @@ distributed_help = 'set this flag if it is distributed training'
 
 # TODO: do something for model type (it is not printed on log)
 global_config = {
-    'version': SEVENN_VERSION,
+    'version': __version__,
     KEY.MODEL_TYPE: 'E3_equivariant_model',
 }
 

--- a/sevenn/main/sevenn_get_model.py
+++ b/sevenn/main/sevenn_get_model.py
@@ -1,12 +1,12 @@
 import argparse
 import os
 
-import sevenn._const as _const
 import sevenn.util
+from sevenn import __version__
 from sevenn.scripts.deploy import deploy, deploy_parallel
 
 description_get_model = (
-    f'sevenn version={_const.SEVENN_VERSION}, sevenn_get_model.'
+    f'sevenn version={__version__}, sevenn_get_model.'
     + ' Deploy model for LAMMPS from the checkpoint'
 )
 checkpoint_help = (

--- a/sevenn/main/sevenn_graph_build.py
+++ b/sevenn/main/sevenn_graph_build.py
@@ -3,13 +3,13 @@ import os
 from datetime import datetime
 
 import sevenn.scripts.graph_build as graph_build
-from sevenn._const import SEVENN_VERSION
+from sevenn import __version__
 from sevenn.sevenn_logger import Logger
 
 description = (
-    f'sevenn version={SEVENN_VERSION}, sevenn_graph_build.\n'
+    f'sevenn version={__version__}, sevenn_graph_build.\n'
     + "Create '.sevenn_data' from ase readable or VASP OUTCARs (by"
-    " structure_list).\n"
+    ' structure_list).\n'
 )
 
 source_help = 'source data to build graph'
@@ -40,7 +40,7 @@ def main(args=None):
         fmt_kwargs,
     ) = cmd_parse_data(args)
     metadata = {
-        'sevenn_version': SEVENN_VERSION,
+        'sevenn_version': __version__,
         'when': now,
         'cutoff': cutoff,
     }

--- a/sevenn/main/sevenn_inference.py
+++ b/sevenn/main/sevenn_inference.py
@@ -4,11 +4,11 @@ import sys
 
 import torch
 
-from sevenn._const import SEVENN_VERSION
+from sevenn import __version__
 from sevenn.scripts.inference import inference_main
 
 description = (
-    f'sevenn version={SEVENN_VERSION}, sevenn_inference. '
+    f'sevenn version={__version__}, sevenn_inference. '
     + 'Evaluate sevenn_data/POSCARs/OUTCARs '
     + 'using the model stored in a checkpoint.'
 )

--- a/sevenn/main/sevenn_patch_lammps.py
+++ b/sevenn/main/sevenn_patch_lammps.py
@@ -2,9 +2,9 @@ import argparse
 import os
 import subprocess
 
-from torch import __version__
+from torch import __version__ as torch_version
 
-from sevenn._const import SEVENN_VERSION
+from sevenn import __version__ as sevenn_version
 
 # python wrapper of patch_lammps.sh script
 # importlib.resources is correct way to do these things
@@ -12,7 +12,7 @@ from sevenn._const import SEVENN_VERSION
 pair_e3gnn_dir = os.path.abspath(f'{os.path.dirname(__file__)}/../pair_e3gnn')
 
 description = (
-    f'sevenn version={SEVENN_VERSION}, patch LAMMPS for pair_e3gnn styles'
+    f'sevenn version={sevenn_version}, patch LAMMPS for pair_e3gnn styles'
 )
 
 
@@ -23,7 +23,7 @@ def main(args=None):
     print('Patching LAMMPS with the following settings:')
     print('  - LAMMPS source directory:', lammps_dir)
 
-    cxx_standard = '17' if __version__.startswith('2') else '14'
+    cxx_standard = '17' if torch_version.startswith('2') else '14'
     if cxx_standard == '17':
         print('  - Torch version >= 2.0 detected, use CXX STANDARD 17')
     else:

--- a/sevenn/main/sevenn_preset.py
+++ b/sevenn/main/sevenn_preset.py
@@ -1,22 +1,22 @@
-import os
 import argparse
+import os
 
-import sevenn._const as _const
+from sevenn import __version__
 
 description_preset = (
-    f'sevenn version={_const.SEVENN_VERSION}, sevenn_preset.'
+    f'sevenn version={__version__}, sevenn_preset.'
     + ' copy paste preset training yaml file to current directory'
     + ' ex) sevennet_preset fine_tune > my_input.yaml'
 )
 
-preset_help = "Name of preset"
+preset_help = 'Name of preset'
 
 
 def main(args=None):
     preset = cmd_parse_preset(args)
     prefix = os.path.abspath(f'{os.path.dirname(__file__)}/../presets')
 
-    with open(f"{prefix}/{preset}.yaml", "r") as f:
+    with open(f'{prefix}/{preset}.yaml', 'r') as f:
         print(f.read())
 
 
@@ -24,7 +24,7 @@ def cmd_parse_preset(args=None):
     ag = argparse.ArgumentParser(description=description_preset)
     ag.add_argument(
         'preset', choices=['fine_tune', 'sevennet-0', 'base'],
-        help = preset_help
+        help=preset_help
     )
     args = ag.parse_args()
     return args.preset

--- a/sevenn/scripts/deploy.py
+++ b/sevenn/scripts/deploy.py
@@ -4,8 +4,8 @@ import e3nn.util.jit
 import torch
 from ase.data import chemical_symbols
 
-import sevenn._const as _const
 import sevenn._keys as KEY
+from sevenn import __version__
 from sevenn.model_build import build_E3_equivariant_model
 
 
@@ -35,7 +35,7 @@ def deploy(model_state_dct, config, fname):
     md_configs.update({'cutoff': str(config[KEY.CUTOFF])})
     md_configs.update({'num_species': str(config[KEY.NUM_SPECIES])})
     md_configs.update({'model_type': config[KEY.MODEL_TYPE]})
-    md_configs.update({'version': _const.SEVENN_VERSION})
+    md_configs.update({'version': __version__})
     md_configs.update({'dtype': config[KEY.DTYPE]})
     md_configs.update({'time': datetime.now().strftime('%Y-%m-%d')})
 
@@ -93,7 +93,7 @@ def deploy_parallel(model_state_dct, config, fname):
     md_configs.update({'num_species': str(config[KEY.NUM_SPECIES])})
     md_configs.update({'comm_size': str(comm_size)})
     md_configs.update({'model_type': config[KEY.MODEL_TYPE]})
-    md_configs.update({'version': _const.SEVENN_VERSION})
+    md_configs.update({'version': __version__})
     md_configs.update({'dtype': config[KEY.DTYPE]})
     md_configs.update({'time': datetime.now().strftime('%Y-%m-%d')})
 

--- a/sevenn/sevenn_logger.py
+++ b/sevenn/sevenn_logger.py
@@ -4,8 +4,8 @@ from datetime import datetime
 
 from ase.data import atomic_numbers
 
-import sevenn._const
 import sevenn._keys as KEY
+from sevenn import __version__
 
 CHEM_SYMBOLS = {v: k for k, v in atomic_numbers.items()}
 
@@ -241,7 +241,7 @@ class Logger(metaclass=Singleton):
         with open(LOGO_ASCII_FILE, 'r') as logo_f:
             logo_ascii = logo_f.read()
         content = 'SEVENN: Scalable EquVariance-Enabled Neural Network\n'
-        content += f'sevenn version {sevenn._const.SEVENN_VERSION}\n'
+        content += f'sevenn version {__version__}\n'
         content += 'reading yaml config...'
         self.write(content)
         self.write(logo_ascii)


### PR DESCRIPTION
This PR adds support for the following behavior:

```python
import sevenn

print(sevenn.__version__)
```

This allows users to programmatically access the version of SevenNet, which is important given model changes.