### PR TITLE
Add options to access the `energy`, `force`, `stress` in ase supported format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## WIP
+### Added
+- energy_key, force_key, stress_key options for `sevenn_graph_build` @thangckt
+### Changed
+- Read EFS of atoms from y_* keys of .info or .arrays dict, instead of caclculator results
+
 ## [0.9.5]
 ### Note
 This version is not stable, but I tag it as v0.9.5 before making further changes.

--- a/sevenn/main/sevenn.py
+++ b/sevenn/main/sevenn.py
@@ -10,19 +10,18 @@ from sevenn.parse_input import read_config_yaml
 from sevenn.scripts.train import train
 from sevenn.sevenn_logger import Logger
 
-description = (
-    f'sevenn version={__version__}, train model based on the input.yaml'
-)
+description = f"sevenn version={__version__}, train model based on the input.yaml"
 
-input_yaml_help = 'input.yaml for training'
-working_dir_help = 'path to write output. Default is cwd.'
-screen_help = 'print log to stdout'
-distributed_help = 'set this flag if it is distributed training'
+input_yaml_help = "input.yaml for training"
+working_dir_help = "path to write output. Default is cwd."
+screen_help = "print log to stdout"
+distributed_help = "set this flag if it is distributed training"
+distributed_backend_help = "backend for distributed training. Supported: nccl, mpi"
 
 # TODO: do something for model type (it is not printed on log)
 global_config = {
-    'version': __version__,
-    KEY.MODEL_TYPE: 'E3_equivariant_model',
+    "version": __version__,
+    KEY.MODEL_TYPE: "E3_equivariant_model",
 }
 
 
@@ -30,17 +29,25 @@ def main(args=None):
     """
     main function of sevenn
     """
-    input_yaml, working_dir, screen, distributed = cmd_parse_main(args)
+    input_yaml, working_dir, screen, distributed, distributed_backend = cmd_parse_main(
+        args
+    )
 
     if working_dir is None:
         working_dir = os.getcwd()
 
     if distributed:
-        local_rank = int(os.environ['LOCAL_RANK'])
-        rank = int(os.environ['RANK'])
-        world_size = int(os.environ['WORLD_SIZE'])
+        if distributed_backend == "nccl":
+            local_rank = int(os.environ["LOCAL_RANK"])
+            rank = int(os.environ["RANK"])
+            world_size = int(os.environ["WORLD_SIZE"])
+        elif distributed_backend == "mpi":
+            local_rank = int(os.environ["OMPI_COMM_WORLD_LOCAL_RANK"])
+            rank = int(os.environ["OMPI_COMM_WORLD_RANK"])
+            world_size = int(os.environ["OMPI_COMM_WORLD_SIZE"])
+
         dist.init_process_group(
-            backend='nccl', world_size=world_size, rank=rank
+            backend=distributed_backend, world_size=world_size, rank=rank
         )
     else:
         local_rank = 0
@@ -48,7 +55,7 @@ def main(args=None):
         world_size = 1
 
     Logger(
-        filename=f'{os.path.abspath(working_dir)}/log.sevenn',
+        filename=f"{os.path.abspath(working_dir)}/log.sevenn",
         screen=screen,
         rank=rank,
     )
@@ -56,7 +63,7 @@ def main(args=None):
 
     if distributed:
         Logger().writeline(
-            f'Distributed training enabled, total world size is {world_size}'
+            f"Distributed training enabled, total world size is {world_size}"
         )
 
     try:
@@ -77,8 +84,8 @@ def main(args=None):
     global_config.update(data_config)
 
     # Not implemented
-    if global_config[KEY.DTYPE] == 'double':
-        raise Exception('double precision is not implemented yet')
+    if global_config[KEY.DTYPE] == "double":
+        raise Exception("double precision is not implemented yet")
         # torch.set_default_dtype(torch.double)
 
     # run train
@@ -87,25 +94,33 @@ def main(args=None):
 
 def cmd_parse_main(args=None):
     ag = argparse.ArgumentParser(description=description)
-    ag.add_argument('input_yaml', help=input_yaml_help, type=str)
+    ag.add_argument("input_yaml", help=input_yaml_help, type=str)
     ag.add_argument(
-        '-w',
-        '--working_dir',
-        nargs='?',
+        "-w",
+        "--working_dir",
+        nargs="?",
         const=os.getcwd(),
         help=working_dir_help,
         type=str,
     )
-    ag.add_argument('-s', '--screen', help=screen_help, action='store_true')
+    ag.add_argument("-s", "--screen", help=screen_help, action="store_true")
+    ag.add_argument("-d", "--distributed", help=distributed_help, action="store_true")
     ag.add_argument(
-        '-d', '--distributed', help=distributed_help, action='store_true'
+        "--distributed_backend",
+        help=distributed_backend_help,
+        type=str,
+        default="nccl",
+        choices=["nccl", "mpi"],
     )
 
     args = ag.parse_args()
     input_yaml = args.input_yaml
     wd = args.working_dir
-    return input_yaml, wd, args.screen, args.distributed
+    screen = args.screen
+    distributed = args.distributed
+    distributed_backend = args.distributed_backend
+    return input_yaml, wd, screen, distributed, distributed_backend
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/sevenn/main/sevenn.py
+++ b/sevenn/main/sevenn.py
@@ -10,18 +10,19 @@ from sevenn.parse_input import read_config_yaml
 from sevenn.scripts.train import train
 from sevenn.sevenn_logger import Logger
 
-description = f"sevenn version={__version__}, train model based on the input.yaml"
+description = (
+    f'sevenn version={__version__}, train model based on the input.yaml'
+)
 
-input_yaml_help = "input.yaml for training"
-working_dir_help = "path to write output. Default is cwd."
-screen_help = "print log to stdout"
-distributed_help = "set this flag if it is distributed training"
-distributed_backend_help = "backend for distributed training. Supported: nccl, mpi"
+input_yaml_help = 'input.yaml for training'
+working_dir_help = 'path to write output. Default is cwd.'
+screen_help = 'print log to stdout'
+distributed_help = 'set this flag if it is distributed training'
 
 # TODO: do something for model type (it is not printed on log)
 global_config = {
-    "version": __version__,
-    KEY.MODEL_TYPE: "E3_equivariant_model",
+    'version': __version__,
+    KEY.MODEL_TYPE: 'E3_equivariant_model',
 }
 
 
@@ -29,25 +30,17 @@ def main(args=None):
     """
     main function of sevenn
     """
-    input_yaml, working_dir, screen, distributed, distributed_backend = cmd_parse_main(
-        args
-    )
+    input_yaml, working_dir, screen, distributed = cmd_parse_main(args)
 
     if working_dir is None:
         working_dir = os.getcwd()
 
     if distributed:
-        if distributed_backend == "nccl":
-            local_rank = int(os.environ["LOCAL_RANK"])
-            rank = int(os.environ["RANK"])
-            world_size = int(os.environ["WORLD_SIZE"])
-        elif distributed_backend == "mpi":
-            local_rank = int(os.environ["OMPI_COMM_WORLD_LOCAL_RANK"])
-            rank = int(os.environ["OMPI_COMM_WORLD_RANK"])
-            world_size = int(os.environ["OMPI_COMM_WORLD_SIZE"])
-
+        local_rank = int(os.environ['LOCAL_RANK'])
+        rank = int(os.environ['RANK'])
+        world_size = int(os.environ['WORLD_SIZE'])
         dist.init_process_group(
-            backend=distributed_backend, world_size=world_size, rank=rank
+            backend='nccl', world_size=world_size, rank=rank
         )
     else:
         local_rank = 0
@@ -55,7 +48,7 @@ def main(args=None):
         world_size = 1
 
     Logger(
-        filename=f"{os.path.abspath(working_dir)}/log.sevenn",
+        filename=f'{os.path.abspath(working_dir)}/log.sevenn',
         screen=screen,
         rank=rank,
     )
@@ -63,7 +56,7 @@ def main(args=None):
 
     if distributed:
         Logger().writeline(
-            f"Distributed training enabled, total world size is {world_size}"
+            f'Distributed training enabled, total world size is {world_size}'
         )
 
     try:
@@ -84,8 +77,8 @@ def main(args=None):
     global_config.update(data_config)
 
     # Not implemented
-    if global_config[KEY.DTYPE] == "double":
-        raise Exception("double precision is not implemented yet")
+    if global_config[KEY.DTYPE] == 'double':
+        raise Exception('double precision is not implemented yet')
         # torch.set_default_dtype(torch.double)
 
     # run train
@@ -94,33 +87,25 @@ def main(args=None):
 
 def cmd_parse_main(args=None):
     ag = argparse.ArgumentParser(description=description)
-    ag.add_argument("input_yaml", help=input_yaml_help, type=str)
+    ag.add_argument('input_yaml', help=input_yaml_help, type=str)
     ag.add_argument(
-        "-w",
-        "--working_dir",
-        nargs="?",
+        '-w',
+        '--working_dir',
+        nargs='?',
         const=os.getcwd(),
         help=working_dir_help,
         type=str,
     )
-    ag.add_argument("-s", "--screen", help=screen_help, action="store_true")
-    ag.add_argument("-d", "--distributed", help=distributed_help, action="store_true")
+    ag.add_argument('-s', '--screen', help=screen_help, action='store_true')
     ag.add_argument(
-        "--distributed_backend",
-        help=distributed_backend_help,
-        type=str,
-        default="nccl",
-        choices=["nccl", "mpi"],
+        '-d', '--distributed', help=distributed_help, action='store_true'
     )
 
     args = ag.parse_args()
     input_yaml = args.input_yaml
     wd = args.working_dir
-    screen = args.screen
-    distributed = args.distributed
-    distributed_backend = args.distributed_backend
-    return input_yaml, wd, screen, distributed, distributed_backend
+    return input_yaml, wd, args.screen, args.distributed
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/sevenn/main/sevenn_graph_build.py
+++ b/sevenn/main/sevenn_graph_build.py
@@ -19,7 +19,6 @@ suffix_help = 'when source is dir, suffix of the files.'
 copy_info_help = 'copy ase.Atoms.info to output dataset'
 format_help = (
     'type of the source, default is structure_list. '
-    + 'If it is pkl/pickle, assume they are list of ase.Atoms. '
     + 'Otherwise, it is directly passed to ase.io.read'
 )
 
@@ -109,7 +108,7 @@ def cmd_parse_data(args=None):
     ag.add_argument(
         '--kwargs',
         nargs=argparse.REMAINDER,
-        help='kwargs to pass to file reader (format)',
+        help='will be passed to ase.io.read, or can be used to specify EFS key',
     )
 
     args = ag.parse_args()

--- a/sevenn/main/sevenn_inference.py
+++ b/sevenn/main/sevenn_inference.py
@@ -32,6 +32,7 @@ def main(args=None):
         args.nworkers,
         device,
         args.batch,
+        args.on_the_fly_graph_build,
     )
 
 

--- a/sevenn/scripts/inference.py
+++ b/sevenn/scripts/inference.py
@@ -232,7 +232,6 @@ def inference_main(  # TODO: re-write
         assert inference_set is not None
 
         inference_set.x_to_one_hot_idx(type_map)
-        inference_set.toggle_requires_grad_of_data(KEY.EDGE_VEC, True)
         infer_list = inference_set.to_list()
         loader = DataLoader(
             infer_list,

--- a/sevenn/train/collate.py
+++ b/sevenn/train/collate.py
@@ -22,6 +22,7 @@ class AtomsToGraphCollater(Collater):
         transfer_info: bool = False,
         follow_batch: Optional[List[str]] = None,
         exclude_keys: Optional[List[str]] = None,
+        y_from_calc: bool = True,
     ):
         # quite original collator's type mismatch with []
         super().__init__([], follow_batch, exclude_keys)
@@ -30,6 +31,7 @@ class AtomsToGraphCollater(Collater):
         self.type_map = type_map
         self.requires_grad_key = requires_grad_key
         self.transfer_info = transfer_info
+        self.y_from_calc = y_from_calc
         self.key_x = key_x
 
     def _Z_to_onehot(self, Z):
@@ -42,7 +44,10 @@ class AtomsToGraphCollater(Collater):
         graph_list = []
         for stct in batch:
             graph = atoms_to_graph(
-                stct, self.cutoff, transfer_info=self.transfer_info
+                stct,
+                self.cutoff,
+                transfer_info=self.transfer_info,
+                y_from_calc=self.y_from_calc,
             )
             graph = AtomGraphData.from_numpy_dict(graph)
             graph[self.key_x] = self._Z_to_onehot(graph[self.key_x])

--- a/sevenn/train/dataload.py
+++ b/sevenn/train/dataload.py
@@ -1,5 +1,4 @@
 import os.path
-import pickle
 from functools import partial
 from itertools import islice
 from typing import Callable, List, Optional

--- a/sevenn/train/dataload.py
+++ b/sevenn/train/dataload.py
@@ -253,20 +253,6 @@ def ase_reader(
     return set_atoms_y(atoms_list, energy_key, force_key, stress_key)
 
 
-# deprecated
-def pkl_atoms_reader(fname):
-    """
-    Assume the content is plane list of ase.Atoms
-    """
-    with open(fname, 'rb') as f:
-        atoms_list = pickle.load(f)
-    if not isinstance(atoms_list, list):
-        raise TypeError('The content of the pkl is not list')
-    if not isinstance(atoms_list[0], ase.Atoms):
-        raise TypeError('The content of the pkl is not list of ase.Atoms')
-    return atoms_list
-
-
 # Reader
 def structure_list_reader(filename: str, format_outputs='vasp-out'):
     parsers = DefaultParsersContainer(
@@ -359,10 +345,7 @@ def structure_list_reader(filename: str, format_outputs='vasp-out'):
 def match_reader(reader_name: str, **kwargs):
     reader = None
     metadata = {}
-    if reader_name == 'pkl' or reader_name == 'pickle':
-        reader = partial(pkl_atoms_reader, **kwargs)
-        metadata.update({'origin': 'atoms_pkl'})
-    elif reader_name == 'structure_list':
+    if reader_name == 'structure_list':
         reader = partial(structure_list_reader, **kwargs)
         metadata.update({'origin': 'structure_list'})
     else:


### PR DESCRIPTION
This PR solve issue #87, and may be solve also issue #61 

Usage:
```python
sevenn_graph_build -f ase my_train_data.extxyz 5.0 --kwargs energy_key='my_energy' force_key=`my_force` stress_key=`my_stress`
```

