### PR TITLE
chore: update dependencies (PyG >= 2.5.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "e3nn",
     "tqdm",
     "scikit-learn",
-    "torch_geometric",
+    "torch_geometric>=2.5.0",
     "numpy<2.0",
 ]
 


### PR DESCRIPTION
`force_reload` key for `InMemoryDataset` of PyG appease after that version